### PR TITLE
Add xAxisOverflow config to Heatmap 

### DIFF
--- a/packages/charts/src/chart_types/heatmap/layout/config/config.ts
+++ b/packages/charts/src/chart_types/heatmap/layout/config/config.ts
@@ -48,6 +48,11 @@ export const config: Config = {
 
   timeZone: 'UTC',
 
+  xAxisOverflow: {
+    left: undefined,
+    right: undefined,
+  },
+
   xAxisLabel: {
     name: 'X Value',
     visible: true,

--- a/packages/charts/src/chart_types/heatmap/layout/types/config_types.ts
+++ b/packages/charts/src/chart_types/heatmap/layout/types/config_types.ts
@@ -28,6 +28,15 @@ import { Cell } from './viewmodel_types';
 export interface Config {
   width: Pixels;
   height: Pixels;
+  /**
+   * Override the computed left and right overflow margin
+   * Helpful if fixed positioning is required
+   * e.g. ending right position will be overall width - xAxisOverflow.right
+   */
+  xAxisOverflow?: {
+    right?: number;
+    left?: number;
+  };
   margin: { left: SizeRatio; right: SizeRatio; top: SizeRatio; bottom: SizeRatio };
   maxRowHeight: Pixels;
   maxColumnWidth: Pixels;

--- a/packages/charts/src/chart_types/heatmap/state/selectors/get_x_axis_right_overflow.ts
+++ b/packages/charts/src/chart_types/heatmap/state/selectors/get_x_axis_right_overflow.ts
@@ -28,18 +28,24 @@ import { getHeatmapTableSelector } from './get_heatmap_table';
 
 /**
  * @internal
- * Gets color scale based on specification and values range.
+ * Gets the optimal width to pad the x axis on the right
+ * based on the text width or on the configured overflow.
  */
 export const getXAxisRightOverflow = createCachedSelector(
   [getHeatmapConfigSelector, getHeatmapTableSelector],
-  ({ xAxisLabel: { fontSize, fontFamily, padding, formatter, width }, timeZone }, { xDomain }): number => {
+  (
+    { xAxisLabel: { fontSize, fontFamily, padding, formatter, width }, xAxisOverflow, timeZone },
+    { xDomain },
+  ): number => {
     if (xDomain.type !== ScaleType.Time) {
       return 0;
     }
-    if (typeof width === 'number') {
-      return width / 2;
+    // Use the configured overflow if xAxisOverflow.right is defined
+    if (typeof xAxisOverflow?.right === 'number') {
+      return xAxisOverflow.right;
     }
 
+    // Else compute the optimal width based on the text size of the last tick label
     const timeScale = new ScaleContinuous(
       {
         type: ScaleType.Time,


### PR DESCRIPTION
## Summary

<!--
  Summarize your PR. This will be included in our newsletter

  - The summary is intended for a consumer audience, avoid any internal or implementation details. You can include those in the details section.
  - Generally only `fix:` and `feat:` PRs will be included in the newsletter. Also, PRs with BREAKING CHANGES are added.
  - Describe the feature or fix as you would if you were advertising it in the newsletter:
      - ❌ : This commit close the request `#123` and adds the prop `helloWorld` to `Settings`
      - ✅ : The `helloWorld` prop is now available in the `Settings` component to bring joy when rendering the chart.
      - ❌ : Fixing the tooltip position outside the chart area avoiding overflows.
      - ✅ : The tooltip no longer overflows the chart DOM container when using the `tooltip.boundary = 'chart'` in the `Settings` component.
  - Add a clear screenshot or animated gif as an example if the change can be understood better and easier with a visual aid.
  - If the PR involves a bigger feature, please add more context to it, describing why the feature was added, what actually improve, and how the users can leverage it to improve their data visualizations
  - If the PR involves a breaking change include the following part and clearly state which contract is broken:

    ### BREAKING CHANGE
    The `tooltip.boundary` prop in the `Settings` component now only accepts a single DOM element ID.
-->



<!-- screenshot/gif/mpeg-4 for visual changes -->


## Details

<!-- Details beyond the summary to explain nuances -->


## Issues

<!--
  Issues this pr is fixing or closing

  e.g.

  This completes a missing feature requested by APM regarding the tooltip positioning #921
  fix #1108
-->



### Checklist

<!-- Delete any items that are not applicable to this PR. -->
- [ ] The proper chart type label was added (e.g. :xy, :partition) if the PR involves a specific chart type
- [ ] The proper feature label was added (e.g. :interactions, :axis) if the PR involves a specific chart feature
- [ ] Whenever possible, please check if the closing issue is connected to a running GH project
- [ ] Any consumer-facing exports were added to `packages/charts/src/index.ts` (and stories only import from `../src` except for test data & storybook)
- [ ] This was checked for cross-browser compatibility
- [ ] Proper documentation or storybook story was added for features that require explanation or tutorials
- [ ] Unit tests were updated or added to match the most common scenarios
